### PR TITLE
1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.1.0] - 2022-11-27
+### Added
+- Added a new setting that excepts an array of name/days tuples to extend the item list.  Ex: [['Rations, ripe', 2], ['Rations, preserved', 365]]
+
+### Changed
+- Adapt existing iron/standard mechanism to utilize new tuple array mechanism by using those two as the first tuples.
+- Linter formatting.
+
+
 ## [1.0.4] - 2022-11-24
 ### Added
 - Add CHANGELOG.md to have a single location for tracking change history conforming to the approach of other modules.
@@ -35,6 +44,7 @@
 ### Initial release
 - Initial release with hard coded names and date spans.
 
+[1.1.0]: https://github.com/JustinFreitas/ration-expiration-date/compare/1.0.4...1.1.0
 [1.0.4]: https://github.com/JustinFreitas/ration-expiration-date/compare/1.0.3...1.0.4
 [1.0.3]: https://github.com/JustinFreitas/ration-expiration-date/compare/1.0.2...1.0.3
 [1.0.2]: https://github.com/JustinFreitas/ration-expiration-date/compare/1.0.1...1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [1.1.0] - 2022-11-27
+## [1.1.0] - 2023-06-25
 ### Added
-- Added a new setting that excepts an array of name/days tuples to extend the item list.  Ex: [['Rations, ripe', 2], ['Rations, preserved', 365]]
+- Added a new setting that excepts an array of name/days tuples to extend the item list.  Ex: [["Rations, ripe", 2], ["Rations, preserved", 365]]
 
 ### Changed
 - Adapt existing iron/standard mechanism to utilize new tuple array mechanism by using those two as the first tuples.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "id": "ration-expiration-date",
     "title": "Ration Expiration Date",
     "description": "When dropping iron or standard rations into an inventory, this module will add a date to the title that is eight or two weeks out, respectively.",
-    "version": "1.0.4",
+    "version": "1.1.0",
     "authors": [
         {
             "name": "Justin Freitas"
@@ -17,5 +17,5 @@
     ],
     "url": "https://github.com/JustinFreitas/ration-expiration-date/",
     "manifest": "https://raw.githubusercontent.com/JustinFreitas/ration-expiration-date/master/module.json",
-    "download": "https://github.com/JustinFreitas/ration-expiration-date/releases/download/1.0.4/ration-expiration-date.zip"
+    "download": "https://github.com/JustinFreitas/ration-expiration-date/releases/download/1.1.0/ration-expiration-date.zip"
 }

--- a/scripts/ration-expiration-date.js
+++ b/scripts/ration-expiration-date.js
@@ -51,7 +51,7 @@ Hooks.on("init", function() {
 
     game.settings.register(MODULE_NAME, JSON_ARRAY_OF_ITEM_AND_DAY_TUPLES, {
         name: "JSON Array of Item and Day Tuples",
-        hint: "A way to supply more item/expiration-day combos beyond the hardcoded two above. Ex: [['Rations, ripe', 2], ['Rations, preserved', 365]]",
+        hint: "A way to supply more item/expiration-day combos beyond the hardcoded two above. Ex: [[\"Rations, ripe\", 2], [\"Rations, preserved\", 365]]",
         scope: world,
         config: true,
         type: String,
@@ -70,7 +70,7 @@ Hooks.on("preCreateItem", (document) => {
     ];
 
     const additionalItemsSettingValue = game.settings.get(MODULE_NAME, JSON_ARRAY_OF_ITEM_AND_DAY_TUPLES).toString();
-    const additionalItems = null;
+    let additionalItems = null;
     try {
         console.log(additionalItemsSettingValue);
         additionalItems = JSON.parse(additionalItemsSettingValue);

--- a/scripts/ration-expiration-date.js
+++ b/scripts/ration-expiration-date.js
@@ -1,8 +1,10 @@
+const DAY = 8.64e+7;
 const MODULE_NAME = "ration-expiration-date";
 const IRON_RATIONS_ITEM_NAME = "ironRationsItemName";
 const IRON_RATIONS_ITEM_NAME_DEFAULT = "Rations, iron";
 const IRON_RATIONS_EXPIRE_DAYS = "ironRationsExpireDays";
 const IRON_RATIONS_EXPIRE_DAYS_DEFAULT = 56;
+const JSON_ARRAY_OF_ITEM_AND_DAY_TUPLES = "jsonArrayOfItemAndDayTuples";
 const STANDARD_RATIONS_ITEM_NAME = "standardRationsItemName";
 const STANDARD_RATIONS_ITEM_NAME_DEFAULT = "Rations, standard";
 const STANDARD_RATIONS_EXPIRE_DAYS = "standardRationsExpireDays";
@@ -46,24 +48,61 @@ Hooks.on("init", function() {
         type: Number,
         default: STANDARD_RATIONS_EXPIRE_DAYS_DEFAULT
     });
+
+    game.settings.register(MODULE_NAME, JSON_ARRAY_OF_ITEM_AND_DAY_TUPLES, {
+        name: "JSON Array of Item and Day Tuples",
+        hint: "A way to supply more item/expiration-day combos beyond the hardcoded two above. Ex: [['Rations, ripe', 2], ['Rations, preserved', 365]]",
+        scope: world,
+        config: true,
+        type: String,
+        default: ""
+    });
 });
 
 Hooks.on("preCreateItem", (document) => {
-    const ironRationsItemName = game.settings.get(MODULE_NAME, IRON_RATIONS_ITEM_NAME) || IRON_RATIONS_ITEM_NAME_DEFAULT;
-    const standardRationsItemName = game.settings.get(MODULE_NAME, STANDARD_RATIONS_ITEM_NAME) || STANDARD_RATIONS_ITEM_NAME_DEFAULT;
+    const ironRationsItemName = game.settings.get(MODULE_NAME, IRON_RATIONS_ITEM_NAME);
+    const standardRationsItemName = game.settings.get(MODULE_NAME, STANDARD_RATIONS_ITEM_NAME);
+    const ironRationsExpireDays = game.settings.get(MODULE_NAME, IRON_RATIONS_EXPIRE_DAYS);
+    const standardRationsExpireDays = game.settings.get(MODULE_NAME, STANDARD_RATIONS_EXPIRE_DAYS);
+    const itemAndDayTuples = [
+        [ironRationsItemName, ironRationsExpireDays],
+        [standardRationsItemName, standardRationsExpireDays]
+    ];
+
+    const additionalItemsSettingValue = game.settings.get(MODULE_NAME, JSON_ARRAY_OF_ITEM_AND_DAY_TUPLES).toString();
+    const additionalItems = null;
+    try {
+        console.log(additionalItemsSettingValue);
+        additionalItems = JSON.parse(additionalItemsSettingValue);
+    } catch (err) {
+        console.log(`Error parsing the item/days tuple array for ${MODULE_NAME}.`)
+    }
+
+    if (Array.isArray(additionalItems)) {
+        itemAndDayTuples.push(...additionalItems);
+    }
 
     if (document?.ownership
-        && Object.keys(document.ownership).length > 1
-        && (document.name === ironRationsItemName
-            || document.name === standardRationsItemName)) {
-        const day = 8.64e+7;
-        const ironRationsExpireDays = game.settings.get(MODULE_NAME, IRON_RATIONS_EXPIRE_DAYS) || IRON_RATIONS_EXPIRE_DAYS_DEFAULT;
-        const standardRationsExpireDays = game.settings.get(MODULE_NAME, STANDARD_RATIONS_EXPIRE_DAYS) || STANDARD_RATIONS_EXPIRE_DAYS_DEFAULT;
-        const expirationDateValue = document.name === standardRationsItemName
-                                        ? day * standardRationsExpireDays
-                                        : day * ironRationsExpireDays;
-        const expirationDate = new Date(Date.now() + expirationDateValue);
-        const updatedName = `${document.name} (${expirationDate.toLocaleDateString()})`;
-        document.data.update({ name: updatedName });
+        && Object.keys(document.ownership).length > 1) {
+        const days = findNameAndReturnDays(itemAndDayTuples, document.name);
+        updateItemNameWithDate(document, days);
     }
 });
+
+function findNameAndReturnDays(tuples, name) {
+    const matchedItemTuple = tuples.find((tuple) => Array.isArray(tuple) && tuple[0] === name);
+    return matchedItemTuple === undefined
+            ? null
+            : matchedItemTuple[1];
+}
+
+function updateItemNameWithDate(document, days) {
+    if (days !== null) {
+        const expirationDateValue = DAY * days;
+        if (!Number.isNaN(expirationDateValue)) {
+            const expirationDate = new Date(Date.now() + expirationDateValue);
+            const updatedName = `${document.name} (${expirationDate.toLocaleDateString()})`;
+            document.data.update({ name: updatedName });
+        }
+    }
+}


### PR DESCRIPTION
Added a new setting that excepts an array of name/days tuples to extend the item list.  Ex: [["Rations, ripe", 2], ["Rations, preserved", 365]]