### PR TITLE
1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.2.0] - 2023-07-29
+### Added
+- Added the option to use SimpleCalendar module as the expiration date source instead of the real world calendar.  That will work if the option is enabled and SimpleCalendar is installed and active in the world.
+
+
 ## [1.1.0] - 2023-06-25
 ### Added
 - Added a new setting that excepts an array of name/days tuples to extend the item list.  Ex: [["Rations, ripe", 2], ["Rations, preserved", 365]]

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ A Foundry VTT module that will watch for the drag of ration items from the compe
 
 Added a new setting that excepts an array of name/days tuples to extend the item list so that custom items beyond the original two can be added in.
 Example, also shown in the settings UI: [["Rations, ripe", 2], ["Rations, preserved", 365]]
+
+Now, the module has an option in the settings to use SimpleCalendar.  That will work if the option is enabled and SimpleCalendar is installed and active in the world.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "id": "ration-expiration-date",
     "title": "Ration Expiration Date",
     "description": "When dropping iron or standard rations into an inventory, this module will add a date to the title that is eight or two weeks out, respectively.",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "authors": [
         {
             "name": "Justin Freitas"
@@ -17,5 +17,5 @@
     ],
     "url": "https://github.com/JustinFreitas/ration-expiration-date/",
     "manifest": "https://raw.githubusercontent.com/JustinFreitas/ration-expiration-date/master/module.json",
-    "download": "https://github.com/JustinFreitas/ration-expiration-date/releases/download/1.1.0/ration-expiration-date.zip"
+    "download": "https://github.com/JustinFreitas/ration-expiration-date/releases/download/1.2.0/ration-expiration-date.zip"
 }


### PR DESCRIPTION
Added the option to use SimpleCalendar module as the expiration date source instead of the real world calendar.  That will work if the option is enabled and SimpleCalendar is installed and active in the world.